### PR TITLE
Flatten KDTree

### DIFF
--- a/lib/kdtree.cpp
+++ b/lib/kdtree.cpp
@@ -419,6 +419,7 @@ private:
  */
 std::vector<detail::FlatNode> flatten(std::unique_ptr<TreeNode> root) {
     static constexpr uint32_t INVALID_INDEX = 0xFFFFFFFF >> 2;
+    const detail::FlatNode sentinel(Axis::X, 0, 0);
     std::vector<detail::FlatNode> nodes;
 
     // do DFS through nodes
@@ -458,7 +459,7 @@ std::vector<detail::FlatNode> flatten(std::unique_ptr<TreeNode> root) {
                 // half-empty node can be used as a sentinel
             } else {
                 // add inner node as sentinel
-                nodes.emplace_back(Axis::X, 0, 0);
+                nodes.push_back(sentinel);
             }
         }
     }

--- a/lib/kdtree.cpp
+++ b/lib/kdtree.cpp
@@ -3,351 +3,443 @@
 #include "clipping.h"
 #include "intersection.h"
 
-#include <stack>
-
 namespace {
 
-// Cf. [WH06], 5.2, Table 1
-static constexpr int COST_TRAVERSAL = 15;
-static constexpr int COST_INTERSECTION = 20;
-
-// Cost function bias
-float lambda(size_t num_ltris, size_t num_rtris) {
-    if (num_ltris == 0 || num_rtris == 0) {
-        return 0.8f;
-    }
-    return 1;
-}
+using TriangleId = detail::TriangleId;
+using TriangleIds = detail::TriangleIds;
 
 /**
- * Cost function of splitting box b at a given plane p
- *
- * Args:
- *   {l,r}area_ratio - ratio of the surface area of the left resp. right
- *     box over the box
- *   num_{l,r}tris - number of triangles in the left resp. right box
- *
- * Return:
- *   cost to split the box
+ * Dynamically allocated KDTree node.
  */
-float cost(float larea_ratio, float rarea_ratio, size_t num_ltris,
-           size_t num_rtris) {
-    return lambda(num_ltris, num_rtris) *
-           (COST_TRAVERSAL +
-            COST_INTERSECTION *
-                (larea_ratio * num_ltris + rarea_ratio * num_rtris));
-}
+class TreeNode {
+public:
+    TreeNode(Axis split_axis, float split_pos, TreeNode* left, TreeNode* right)
+        : flags_(static_cast<TriangleId>(split_axis) + FLAG_AXIS_X)
+        , split_pos_(split_pos)
+        , left_or_triangle_ids_(static_cast<void*>(left))
+        , right_(right) {}
 
-enum class Dir { LEFT, RIGHT };
-
-/**
- * SAH function
- *
- * Args:
- *   ax, pos: splitting plane
- *   box: AABB to split
- *   num_{l,r}tris: number of triangles in the left resp. right box produces
- *     by splitting `box` at `p`
- *   num_ptris: number of triangles lying in the plane `p`
- *
- * Return:
- *   cost to split the box + wether the planar triangles should be appended to
- *   the lhs or rhs of the box
- */
-std::pair<float /*cost*/, Dir>
-surface_area_heuristics(Axis ax, float pos, const Box& box, size_t num_ltris,
-                        size_t num_rtris, size_t num_ptris) {
-    Box lbox, rbox;
-    std::tie(lbox, rbox) = box.split(ax, pos);
-    float area = box.surface_area();
-    float larea_ratio = lbox.surface_area() / area;
-    float rarea_ratio = rbox.surface_area() / area;
-
-    auto left_planar_cost =
-        cost(larea_ratio, rarea_ratio, num_ltris + num_ptris, num_rtris);
-    auto right_planar_cost =
-        cost(larea_ratio, rarea_ratio, num_ltris, num_ptris + num_rtris);
-
-    if (left_planar_cost < right_planar_cost) {
-        return {left_planar_cost, Dir::LEFT};
-    } else {
-        return {right_planar_cost, Dir::RIGHT};
-    }
-}
-} // namespace anonymous
-
-KDTree::KDTree(Triangles tris) : tris_(std::move(tris)) {
-    assert(tris_.size() > 0);
-    assert(tris_.size() <= Node::MAX_ID);
-
-    std::vector<TriangleId> ids(tris_.size(), 0);
-
-    box_ = tris_.front().bbox();
-    for (size_t i = 1; i < tris_.size(); ++i) {
-        box_ = box_ + tris_[i].bbox();
-        ids[i] = i;
+    explicit TreeNode(const std::vector<TriangleId>& ids) : flags_(ids.size()) {
+        TriangleId* triangle_ids = new TriangleId[ids.size()];
+        ::memcpy(triangle_ids, ids.data(), ids.size() * sizeof(TriangleId));
+        left_or_triangle_ids_ = static_cast<void*>(triangle_ids);
     }
 
-    root_ = std::unique_ptr<Node>(build(std::move(ids), box_));
-    flatten();
-}
-
-KDTree::Node* KDTree::build(KDTree::TriangleIds tris, const Box& box) {
-    if (tris.size() == 0) {
-        return nullptr;
-    }
-
-    // to few triangles -> terminate
-    if (tris.size() <= 3) {
-        return new Node(tris);
-    }
-
-    // box too small -> no need to split further -> terminate
-    if (box.surface_area() == 0) {
-        return new Node(tris);
-    }
-
-    float min_cost;
-    Axis plane_ax;
-    float plane_pos; // plane
-    TriangleIds ltris, rtris;
-    std::tie(min_cost, plane_ax, plane_pos, ltris, rtris) =
-        find_plane_and_classify(tris, box);
-
-    // automatic termination
-    // remove lambda factor from cost again, otherwise we may stuck in an
-    // empty space split forever
-    if (COST_INTERSECTION * tris.size() * lambda(ltris.size(), rtris.size()) <
-        min_cost) {
-        return new Node(tris);
-    }
-
-    Box lbox, rbox;
-    std::tie(lbox, rbox) = box.split(plane_ax, plane_pos);
-
-    Node* left = build(std::move(ltris), lbox);
-    Node* right = build(std::move(rtris), rbox);
-    assert(left || right);
-
-    if (!left) {
-        return right;
-    } else if (!right) {
-        return left;
-    }
-    return new Node(plane_ax, plane_pos, left, right);
-}
-
-std::tuple<float /*cost*/, Axis /* plane axis */, float /* plane pos */,
-           KDTree::TriangleIds /*left*/, KDTree::TriangleIds /*right*/>
-KDTree::find_plane_and_classify(const TriangleIds& tris, const Box& box) const {
-    // The box should have some surface, otherwise the surface area heuristics
-    // does not make any sense.
-    assert(box.surface_area() != 0);
-
-    // auxiliary event structure
-    static constexpr int STARTING = 2;
-    static constexpr int ENDING = 0;
-    static constexpr int PLANAR = 1;
-
-    struct Event {
-        TriangleId id;
-        float point;
-        // auxiliary point
-        // for type == ENDING, point_aux is the starting point
-        // for type == STARTNG, point_aux is the ending point
-        // for type == PLANAR, points_aux is the same point as `point`
-        float point_aux;
-        int type;
-    };
-
-    // PERF: move out in front of recursion
-    std::vector<Event> event_lists[AXES.size()];
-
-    // generate events
-    size_t num_tris = 0;
-    for (const auto& id : tris) {
-        auto clipped_box = clip_triangle_at_aabb(tris_[id], box);
-        if (clipped_box.is_trivial()) {
-            continue;
+    ~TreeNode() {
+        if (is_inner()) {
+            if (left()) {
+                delete left();
+            }
+            if (right()) {
+                delete right();
+            }
+        } else {
+            delete[] triangle_ids();
         }
-        num_tris += 1;
+    }
+
+    // attributes
+
+    bool is_leaf() const { return flags_ <= MAX_ID; }
+
+    bool is_inner() const { return !is_leaf(); }
+
+    Axis split_axis() const {
+        assert(is_inner());
+
+        if (flags_ == FLAG_AXIS_X) {
+            return Axis::X;
+        } else if (flags_ == FLAG_AXIS_Y) {
+            return Axis::Y;
+        } else if (flags_ == FLAG_AXIS_Z) {
+            return Axis::Z;
+        }
+
+        assert(false);
+        return Axis::X;
+    }
+
+    float split_pos() const {
+        assert(is_inner());
+        return split_pos_;
+    }
+
+    TreeNode* left() const {
+        assert(is_inner());
+        return reinterpret_cast<TreeNode*>(left_or_triangle_ids_);
+    }
+
+    TreeNode* right() const {
+        assert(is_inner());
+        return right_;
+    }
+
+    TriangleId num_tris() const {
+        assert(is_leaf());
+        return flags_;
+    }
+
+    TriangleId* triangle_ids() const {
+        assert(is_leaf());
+        return reinterpret_cast<TriangleId*>(left_or_triangle_ids_);
+    }
+
+    // the last 3 values are reserved for axis description
+    static constexpr TriangleId MAX_ID =
+        std::numeric_limits<TriangleId>::max() - 3;
+
+private:
+    static constexpr TriangleId FLAG_AXIS_X = MAX_ID + 1;
+    static constexpr TriangleId FLAG_AXIS_Y = MAX_ID + 2;
+    static constexpr TriangleId FLAG_AXIS_Z = MAX_ID + 3;
+
+    // If flags_ in [0, MAX_ID], then this node is a leaf node and this
+    // member is the number of triangles in the leaf. Otherwise, this node
+    // is an inner node. In this case, flags is in [FLAG_AXIS_X,
+    // FLAG_AXIS_Y, FLAG_AXIS_Z] and describes the splitting axis.
+    TriangleId flags_; // 4 bytes
+    // Used only in an inner node
+    float split_pos_; // 4 bytes
+    // Depending whether this node is an inner node or a leaf, this member
+    // is a pointer to the left child or resp. the array containing the
+    // triangles.
+    void* left_or_triangle_ids_; // 8 bytes
+    // Used only in an inner node
+    TreeNode* right_; // 8 bytes
+                      // == 24 bytes
+};
+
+/**
+ * Self contained implementation of Algorithm 4 from:
+ *
+ * "On building fast kd-Trees for Ray Tracing, and on doing that in O(N log N)"
+ * by Ingo Wald and Vlastimil Havran
+ * [WH06]
+ *
+ * Builds up a kd-tree in O(N log^2 N), however the resulting kd-tree is the
+ * same as if it were built with Algorithm 5.
+ *
+ * TODO: Replace by Algorithm 5.
+ */
+class KDTreeBuildAlgorithm {
+public:
+    KDTreeBuildAlgorithm(const Triangles& triangles) : triangles_(&triangles) {}
+
+    TreeNode* build(TriangleIds tris, const Box& box) {
+        using Node = TreeNode;
+
+        if (tris.size() == 0) {
+            return nullptr;
+        }
+
+        // to few triangles -> terminate
+        if (tris.size() <= 3) {
+            return new Node(tris);
+        }
+
+        // box too small -> no need to split further -> terminate
+        if (box.surface_area() == 0) {
+            return new Node(tris);
+        }
+
+        float min_cost;
+        Axis plane_ax;
+        float plane_pos; // plane
+        TriangleIds ltris, rtris;
+        std::tie(min_cost, plane_ax, plane_pos, ltris, rtris) =
+            find_plane_and_classify(tris, box);
+
+        // automatic termination
+        // remove lambda factor from cost again, otherwise we may stuck in an
+        // empty space split forever
+        if (COST_INTERSECTION * tris.size() *
+                lambda(ltris.size(), rtris.size()) <
+            min_cost) {
+            return new Node(tris);
+        }
+
+        Box lbox, rbox;
+        std::tie(lbox, rbox) = box.split(plane_ax, plane_pos);
+
+        Node* left = build(std::move(ltris), lbox);
+        Node* right = build(std::move(rtris), rbox);
+        assert(left || right);
+
+        if (!left) {
+            return right;
+        } else if (!right) {
+            return left;
+        }
+        return new Node(plane_ax, plane_pos, left, right);
+    }
+
+private:
+    // Cf. [WH06], 5.2, Table 1
+    static constexpr int COST_TRAVERSAL = 15;
+    static constexpr int COST_INTERSECTION = 20;
+
+    // Cost function bias
+    float lambda(size_t num_ltris, size_t num_rtris) const {
+        if (num_ltris == 0 || num_rtris == 0) {
+            return 0.8f;
+        }
+        return 1;
+    }
+
+    /**
+     * Cost function of splitting box b at a given plane p
+     *
+     * @param  {l,r}area_ratio ratio of the surface area of the left resp.
+     *         right box over the box
+     * @param  num_{l,r}tris   number of triangles in the left resp. right box
+     * @return cost to split the box
+     */
+    float cost(float larea_ratio, float rarea_ratio, size_t num_ltris,
+               size_t num_rtris) const {
+        return lambda(num_ltris, num_rtris) *
+               (COST_TRAVERSAL +
+                COST_INTERSECTION *
+                    (larea_ratio * num_ltris + rarea_ratio * num_rtris));
+    }
+
+    enum class Dir { LEFT, RIGHT };
+
+    /**
+     * SAH function
+     *
+     * @param  ax, pos       splitting plane
+     * @param  box           AABB to split
+     * @param  num_{l,r}tris number of triangles in the left resp. right box
+     *                       produces by splitting `box` at `p`
+     * @param  num_ptris     number of triangles lying in the plane `p`
+     * @return cost to split the box + whether the planar triangles should be
+     *         appended to the lhs or rhs of the box.
+     */
+    std::pair<float /*cost*/, Dir>
+    surface_area_heuristics(Axis ax, float pos, const Box& box,
+                            size_t num_ltris, size_t num_rtris,
+                            size_t num_ptris) const {
+        Box lbox, rbox;
+        std::tie(lbox, rbox) = box.split(ax, pos);
+        float area = box.surface_area();
+        float larea_ratio = lbox.surface_area() / area;
+        float rarea_ratio = rbox.surface_area() / area;
+
+        auto left_planar_cost =
+            cost(larea_ratio, rarea_ratio, num_ltris + num_ptris, num_rtris);
+        auto right_planar_cost =
+            cost(larea_ratio, rarea_ratio, num_ltris, num_ptris + num_rtris);
+
+        if (left_planar_cost < right_planar_cost) {
+            return {left_planar_cost, Dir::LEFT};
+        } else {
+            return {right_planar_cost, Dir::RIGHT};
+        }
+    }
+
+    /**
+     * [WH06], Algorithm 4
+     */
+    std::tuple<float /*cost*/, Axis /* plane axis */, float /* plane pos */,
+               TriangleIds /*left*/, TriangleIds /*right*/>
+    find_plane_and_classify(const TriangleIds& tris, const Box& box) const {
+        // The box should have some surface, otherwise the surface area
+        // heuristics
+        // does not make any sense.
+        assert(box.surface_area() != 0);
+
+        // auxiliary event structure
+        static constexpr int STARTING = 2;
+        static constexpr int ENDING = 0;
+        static constexpr int PLANAR = 1;
+
+        struct Event {
+            TriangleId id;
+            float point;
+            // auxiliary point
+            // for type == ENDING, point_aux is the starting point
+            // for type == STARTNG, point_aux is the ending point
+            // for type == PLANAR, points_aux is the same point as `point`
+            float point_aux;
+            int type;
+        };
+
+        // PERF: move out in front of recursion
+        std::vector<Event> event_lists[AXES.size()];
+
+        // generate events
+        size_t num_tris = 0;
+        for (const auto& id : tris) {
+            auto clipped_box = clip_triangle_at_aabb((*triangles_)[id], box);
+            if (clipped_box.is_trivial()) {
+                continue;
+            }
+            num_tris += 1;
+
+            for (auto ax : AXES) {
+                auto& events = event_lists[static_cast<int>(ax)];
+                if (clipped_box.is_planar(ax)) {
+                    events.emplace_back(Event{id, clipped_box.min[ax],
+                                              clipped_box.min[ax], PLANAR});
+                } else {
+                    events.emplace_back(Event{id, clipped_box.min[ax],
+                                              clipped_box.max[ax], STARTING});
+                    events.emplace_back(Event{id, clipped_box.max[ax],
+                                              clipped_box.min[ax], ENDING});
+                }
+            }
+        }
+
+        // all clipped?
+        if (num_tris == 0) {
+            return std::make_tuple(std::numeric_limits<float>::max(), Axis::X,
+                                   0, TriangleIds(), TriangleIds());
+        }
+
+        // sweep for min_cost
+        float min_cost = std::numeric_limits<float>::max();
+        Axis min_plane_ax = Axis::X;
+        float min_plane_pos = 0;
+        Dir min_side = Dir::LEFT;
+        // we also store those for asserts below
+        size_t min_ltris = 0;
+        size_t min_rtris = 0;
+        size_t min_ptris = 0;
+        UNUSED(min_ptris);
 
         for (auto ax : AXES) {
             auto& events = event_lists[static_cast<int>(ax)];
-            if (clipped_box.is_planar(ax)) {
-                events.emplace_back(Event{id, clipped_box.min[ax],
-                                          clipped_box.min[ax], PLANAR});
-            } else {
-                events.emplace_back(Event{id, clipped_box.min[ax],
-                                          clipped_box.max[ax], STARTING});
-                events.emplace_back(Event{id, clipped_box.max[ax],
-                                          clipped_box.min[ax], ENDING});
+            std::sort(events.begin(), events.end(),
+                      [](const Event& e1, const Event& e2) {
+                          return e1.point < e2.point ||
+                                 (e1.point == e2.point && e1.type < e2.type);
+                      });
+
+            size_t num_ltris = 0, num_ptris = 0, num_rtris = num_tris;
+
+            for (size_t i = 0; i < events.size();) {
+                auto& event = events[i];
+
+                auto p = event.point;
+                int point_starting = 0;
+                int point_ending = 0;
+                int point_planar = 0;
+
+                while (i < events.size() && events[i].point == p &&
+                       events[i].type == ENDING) {
+                    point_ending += 1;
+                    i += 1;
+                }
+                while (i < events.size() && events[i].point == p &&
+                       events[i].type == PLANAR) {
+                    point_planar += 1;
+                    i += 1;
+                }
+                while (i < events.size() && events[i].point == p &&
+                       events[i].type == STARTING) {
+                    point_starting += 1;
+                    i += 1;
+                }
+
+                num_ptris = point_planar;
+                num_rtris -= point_planar + point_ending;
+
+                float cost;
+                Dir side;
+                std::tie(cost, side) = surface_area_heuristics(
+                    ax, p, box, num_ltris, num_rtris, num_ptris);
+
+                if (cost < min_cost) {
+                    min_cost = cost;
+                    min_plane_ax = ax;
+                    min_plane_pos = p;
+                    min_side = side;
+                    min_ltris = num_ltris;
+                    min_rtris = num_rtris;
+                    min_ptris = num_ptris;
+                }
+
+                num_ltris += point_starting + point_planar;
+                num_ptris = 0;
             }
-        }
-    }
+        } // -> min_plane, min_side
 
-    // all clipped?
-    if (num_tris == 0) {
-        return std::make_tuple(std::numeric_limits<float>::max(), Axis::X, 0,
-                               TriangleIds(), TriangleIds());
-    }
+        assert(min_cost < std::numeric_limits<float>::max());
 
-    // sweep for min_cost
-    float min_cost = std::numeric_limits<float>::max();
-    Axis min_plane_ax = Axis::X;
-    float min_plane_pos = 0;
-    Dir min_side = Dir::LEFT;
-    // we also store those for asserts below
-    size_t min_ltris = 0;
-    size_t min_rtris = 0;
-    size_t min_ptris = 0;
-    UNUSED(min_ptris);
+        // classify
+        TriangleIds ltris, rtris;
+        ltris.reserve(min_ltris);
+        rtris.reserve(min_rtris);
 
-    for (auto ax : AXES) {
-        auto& events = event_lists[static_cast<int>(ax)];
-        std::sort(events.begin(), events.end(),
-                  [](const Event& e1, const Event& e2) {
-                      return e1.point < e2.point ||
-                             (e1.point == e2.point && e1.type < e2.type);
-                  });
-
-        size_t num_ltris = 0, num_ptris = 0, num_rtris = num_tris;
-
-        for (size_t i = 0; i < events.size();) {
-            auto& event = events[i];
-
-            auto p = event.point;
-            int point_starting = 0;
-            int point_ending = 0;
-            int point_planar = 0;
-
-            while (i < events.size() && events[i].point == p &&
-                   events[i].type == ENDING) {
-                point_ending += 1;
-                i += 1;
-            }
-            while (i < events.size() && events[i].point == p &&
-                   events[i].type == PLANAR) {
-                point_planar += 1;
-                i += 1;
-            }
-            while (i < events.size() && events[i].point == p &&
-                   events[i].type == STARTING) {
-                point_starting += 1;
-                i += 1;
-            }
-
-            num_ptris = point_planar;
-            num_rtris -= point_planar + point_ending;
-
-            float cost;
-            Dir side;
-            std::tie(cost, side) = surface_area_heuristics(
-                ax, p, box, num_ltris, num_rtris, num_ptris);
-
-            if (cost < min_cost) {
-                min_cost = cost;
-                min_plane_ax = ax;
-                min_plane_pos = p;
-                min_side = side;
-                min_ltris = num_ltris;
-                min_rtris = num_rtris;
-                min_ptris = num_ptris;
-            }
-
-            num_ltris += point_starting + point_planar;
-            num_ptris = 0;
-        }
-    } // -> min_plane, min_side
-
-    assert(min_cost < std::numeric_limits<float>::max());
-
-    // classify
-    TriangleIds ltris, rtris;
-    ltris.reserve(min_ltris);
-    rtris.reserve(min_rtris);
-
-    const auto& events = event_lists[static_cast<int>(min_plane_ax)];
-    for (const auto& event : events) {
-        if (event.point < min_plane_pos) {
-            if (event.type == ENDING || event.type == PLANAR) {
-                ltris.push_back(event.id);
-            } else if (min_plane_pos < event.point_aux) {
-                // STARTING before and ENDING after min_plane
-                ltris.push_back(event.id);
-                rtris.push_back(event.id);
-            }
-        } else if (event.point == min_plane_pos) {
-            if (event.type == ENDING) {
-                ltris.push_back(event.id);
-            } else if (event.type == PLANAR) {
-                if (min_side == Dir::LEFT) {
+        const auto& events = event_lists[static_cast<int>(min_plane_ax)];
+        for (const auto& event : events) {
+            if (event.point < min_plane_pos) {
+                if (event.type == ENDING || event.type == PLANAR) {
                     ltris.push_back(event.id);
+                } else if (min_plane_pos < event.point_aux) {
+                    // STARTING before and ENDING after min_plane
+                    ltris.push_back(event.id);
+                    rtris.push_back(event.id);
+                }
+            } else if (event.point == min_plane_pos) {
+                if (event.type == ENDING) {
+                    ltris.push_back(event.id);
+                } else if (event.type == PLANAR) {
+                    if (min_side == Dir::LEFT) {
+                        ltris.push_back(event.id);
+                    } else {
+                        rtris.push_back(event.id);
+                    }
                 } else {
                     rtris.push_back(event.id);
                 }
-            } else {
+            } else if (event.type == STARTING || event.type == PLANAR) {
                 rtris.push_back(event.id);
             }
-        } else if (event.type == STARTING || event.type == PLANAR) {
-            rtris.push_back(event.id);
         }
+
+        assert(min_ltris + (min_side == Dir::LEFT ? min_ptris : 0) ==
+               ltris.size());
+        assert(min_rtris + (min_side == Dir::RIGHT ? min_ptris : 0) ==
+               rtris.size());
+
+        return std::make_tuple(min_cost, min_plane_ax, min_plane_pos,
+                               std::move(ltris), std::move(rtris));
     }
 
-    assert(min_ltris + (min_side == Dir::LEFT ? min_ptris : 0) == ltris.size());
-    assert(min_rtris + (min_side == Dir::RIGHT ? min_ptris : 0) ==
-           rtris.size());
+private:
+    const Triangles* triangles_;
+};
 
-    return std::make_tuple(min_cost, min_plane_ax, min_plane_pos,
-                           std::move(ltris), std::move(rtris));
-}
-
-void KDTree::flatten() {
+/**
+ * Flatten dynamically allocated KDTree into an array.
+ *
+ * @param  root node of the KDTree
+ * @return array of nodes representing flattened KDTree
+ */
+std::vector<detail::FlatNode> flatten(std::unique_ptr<TreeNode> root) {
     static constexpr uint32_t INVALID_INDEX = 0xFFFFFFFF >> 2;
-
-    // auto print = [this] {
-    //     size_t i = 0;
-    //     for (auto it = nodes_.begin(); it != nodes_.end(); ++it, ++i) {
-    //         const auto& node = *it;
-    //         if (node.is_inner()) {
-    //             std::cerr << i << ": InnerNode("
-    //                       << static_cast<int>(node.split_axis()) << ", "
-    //                       << node.split_pos() << ", " << node.right() << ")"
-    //                       << std::endl;
-    //         } else {
-    //             if (node.is_empty()) {
-    //                 std::cerr << i << ": Leaf()" << std::endl;
-    //             } else if (node.is_sentinel()) {
-    //                 std::cerr << i << ": Leaf(" << node.first_triangle_id()
-    //                           << ")" << std::endl;
-    //             } else {
-    //                 std::cerr << i << ": Leaf(" << node.first_triangle_id()
-    //                           << ", " << node.second_triangle_id() << ")"
-    //                           << std::endl;
-    //             }
-    //         }
-    //     }
-    // };
+    std::vector<detail::FlatNode> nodes;
 
     // do DFS through nodes
-    std::stack<std::pair<Node*, uint32_t /*parent index*/>> stack;
-    stack.emplace(root_.get(), INVALID_INDEX);
+    std::stack<std::pair<TreeNode*, uint32_t /*parent index*/>> stack;
+    stack.emplace(root.get(), INVALID_INDEX);
 
     while (!stack.empty()) {
-        const Node& node = *stack.top().first;
+        const TreeNode& node = *stack.top().first;
         uint32_t parent_index = stack.top().second;
         stack.pop();
 
-        uint32_t node_index = nodes_.size();
+        uint32_t node_index = nodes.size();
         if (parent_index != INVALID_INDEX) {
             // we are in the right node => update parent's reference
-            nodes_[parent_index].set_right(node_index);
+            nodes[parent_index].set_right(node_index);
         }
 
         if (node.is_inner()) {
             // set right to invalid, since we don't know the index yet
-            nodes_.emplace_back(node.split_axis(), node.split_pos(),
-                                INVALID_INDEX);
+            nodes.emplace_back(node.split_axis(), node.split_pos(),
+                               INVALID_INDEX);
 
             // Push right first, since we visit left first.
             stack.emplace(node.right(), node_index);
@@ -360,18 +452,43 @@ void KDTree::flatten() {
                 if (is_odd) {
                     first_id = triangle_ids[i];
                 } else {
-                    nodes_.emplace_back(first_id, triangle_ids[i]);
+                    nodes.emplace_back(first_id, triangle_ids[i]);
                 }
                 is_odd = !is_odd;
             }
             // add sentinel
             if (!is_odd) {
-                nodes_.emplace_back(first_id);
+                nodes.emplace_back(first_id);
             } else {
-                nodes_.emplace_back();
+                nodes.emplace_back();
             }
         }
     }
+
+    return nodes;
+}
+} // namespace anonymous
+
+//
+// KDTree implementation
+//
+
+KDTree::KDTree(Triangles tris) : tris_(std::move(tris)) {
+    assert(tris_.size() > 0);
+    assert(tris_.size() < detail::FlatNode::MAX_TRIANGLE_ID);
+
+    std::vector<TriangleId> ids(tris_.size(), 0);
+
+    // Compute the bounding box of all triangles and fill in vector of all ids.
+    box_ = tris_.front().bbox();
+    for (size_t i = 1; i < tris_.size(); ++i) {
+        box_ = box_ + tris_[i].bbox();
+        ids[i] = i;
+    }
+
+    KDTreeBuildAlgorithm algo(tris_);
+    nodes_ =
+        flatten(std::unique_ptr<TreeNode>(algo.build(std::move(ids), box_)));
 }
 
 //
@@ -397,80 +514,8 @@ Vec fix_direction(const Ray& ray) {
 
 } // namespace anonymous
 
-/**
- *
- */
-// const KDTree::OptionalId KDTreeIntersection::intersect(const Ray& ray, float&
-// r,
-//                                                        float& a, float& b) {
-//     // A trick to make the traversal robust.
-//     // Cf. [HH11], p. 5, comment about dir classification and robustness.
-//     const Ray fixed_ray(ray.pos, fix_direction(ray));
-
-//     float tenter, texit;
-//     if (!intersect_ray_box(fixed_ray, tree_->box(), tenter, texit)) {
-//         return OptionalId{};
-//     }
-
-//     // Note: No need to clear, since when we leave this function, the stack
-//     is
-//     // always empty.
-//     assert(stack_.empty());
-//     stack_.emplace(tree_->root_.get(), tenter, texit);
-
-//     KDTree::Node* node;
-//     OptionalId res;
-//     r = std::numeric_limits<float>::max();
-//     while (!stack_.empty()) {
-//         std::tie(node, tenter, texit) = stack_.top();
-//         stack_.pop();
-
-//         while (node->is_inner()) {
-//             int ax = static_cast<int>(node->split_axis());
-//             float split_pos = node->split_pos();
-
-//             // t at split
-//             float t = (split_pos - fixed_ray.pos[ax]) * fixed_ray.invdir[ax];
-
-//             // classify near/far with respect to t:
-//             // left is near if ray.dir[ax] <= 0, else otherwise
-//             KDTree::Node* near = node->left();
-//             KDTree::Node* far = node->right();
-//             if (fixed_ray.dir[ax] <= 0) {
-//                 std::swap(near, far);
-//             }
-
-//             if (texit < t) {
-//                 node = near;
-//             } else if (t < tenter) {
-//                 node = far;
-//             } else {
-//                 stack_.emplace(far, t, texit);
-//                 node = near;
-//                 texit = t;
-//             }
-//         }
-
-//         assert(node->is_leaf());
-//         float next_r, next_a, next_b;
-//         auto next = intersect(node->triangle_ids(), node->num_tris(), ray,
-//                               next_r, next_a, next_b);
-//         if (next && next_r < r) {
-//             res = next;
-//             r = next_r;
-//             a = next_a;
-//             b = next_b;
-//         }
-//     }
-
-//     return res;
-// }
-
-/**
- *
- */
-const KDTree::OptionalId KDTreeIntersection::intersect(const Ray& ray, float& r,
-                                                       float& a, float& b) {
+const KDTreeIntersection::OptionalId
+KDTreeIntersection::intersect(const Ray& ray, float& r, float& a, float& b) {
     // A trick to make the traversal robust.
     // Cf. [HH11], p. 5, comment about dir classification and robustness.
     const Ray fixed_ray(ray.pos, fix_direction(ray));
@@ -533,29 +578,7 @@ const KDTree::OptionalId KDTreeIntersection::intersect(const Ray& ray, float& r,
     return res;
 }
 
-// const KDTree::OptionalId
-// KDTreeIntersection::intersect(const KDTree::TriangleId* ids, uint32_t
-// num_tris,
-//                               const Ray& ray, float& min_r, float& min_s,
-//                               float& min_t) {
-//     min_r = std::numeric_limits<float>::max();
-//     OptionalId res;
-//     float r, s, t;
-//     for (uint32_t i = 0; i != num_tris; ++i) {
-//         const auto& tri = tree_->tris_[ids[i]];
-//         bool intersects = intersect_ray_triangle(ray, tri, r, s, t);
-//         if (intersects && r < min_r) {
-//             min_r = r;
-//             min_s = s;
-//             min_t = t;
-//             res = OptionalId{ids[i]};
-//         }
-//     }
-
-//     return res;
-// }
-
-const KDTree::OptionalId
+const KDTreeIntersection::OptionalId
 KDTreeIntersection::intersect(const detail::FlatNode* node, const Ray& ray,
                               float& min_r, float& min_s, float& min_t) {
     min_r = std::numeric_limits<float>::max();

--- a/lib/kdtree.h
+++ b/lib/kdtree.h
@@ -380,13 +380,13 @@ public:
 
 private:
     // Helper method which intersects a triangle ids array with a ray
-    const OptionalId intersect(uint32_t node_index, const Ray& ray,
+    const OptionalId intersect(const detail::FlatNode*, const Ray& ray,
                                float& min_r, float& min_s, float& min_t);
 
 private:
     const KDTree* tree_;
     std::stack<
-        std::tuple<uint32_t /*node index*/, float /*tenter*/, float /*texit*/>>
+        std::tuple<const detail::FlatNode*, float /*tenter*/, float /*texit*/>>
         stack_;
 };
 

--- a/radiosity.cpp
+++ b/radiosity.cpp
@@ -350,7 +350,7 @@ Image render_feature_lines(const KDTree& tree, const RadiosityConfig& conf,
 
             for (size_t x = 0; x < image.width(); ++x) {
                 float dist_to_triangle, s, t;
-                std::unordered_set<KDTree::OptionalId> triangle_ids;
+                std::unordered_set<KDTreeIntersection::OptionalId> triangle_ids;
 
                 // Shoot center ray.
                 auto cam_dir = cam.raster2cam(aiVector2D(x + 0.5f, y + 0.5f),

--- a/tests/test_kdtree.cpp
+++ b/tests/test_kdtree.cpp
@@ -26,10 +26,10 @@ TEST_CASE("Four separated triangles test", "[kdtree]") {
     auto d = test_triangle({3, 2, 1}, {3, 3, 1}, {2, 3, 1});
     KDTree tree(Triangles{a, b, c, d});
     REQUIRE(tree.height() == 1);
-    REQUIRE(tree.size() == 4);
+    REQUIRE(tree.num_nodes() == 5);
 
     KDTreeIntersection tree_intersection(tree);
-    KDTree::OptionalId hit;
+    KDTreeIntersection::OptionalId hit;
     float r, s, t;
 
     hit = tree_intersection.intersect({{0, 0, 0}, {0.5f, 0.5f, 1}}, r, s, t);
@@ -91,7 +91,7 @@ TEST_CASE("KDTree stress test", "[kdtree]") {
     })();
     std::cerr << "Runtime : " << runtime_ms << "ms" << std::endl;
     std::cerr << "Height  : " << tree.height() << std::endl;
-    std::cerr << "Size    : " << tree.size() << std::endl;
+    std::cerr << "Size    : " << tree.num_nodes() << std::endl;
     std::cerr << std::endl;
 
     // test
@@ -149,7 +149,7 @@ TEST_CASE("Test cube in kdtree", "[kdtree]") {
 
     KDTree tree(Triangles{a1, a2, a3, a4, b1, b2, b3, b4, c1, c2, c3, c4});
     REQUIRE(tree.height() == 0);
-    REQUIRE(tree.size() == 12);
+    REQUIRE(tree.num_nodes() == 7);
 }
 
 TEST_CASE("All triangles are in the same plane", "[kdtree]") {
@@ -184,7 +184,7 @@ TEST_CASE("Degenerated triangles test", "[KDTree]") {
     tris.push_back(test_triangle({0, 0, 0}, {1, 0, 0}, {2, 0, 0}));
 
     KDTree tree(tris);
-    REQUIRE(4 <= tree.size());
+    REQUIRE(3 <= tree.num_nodes());
 }
 
 TEST_CASE("Intersect coplanar triangles", "[KDTree]") {
@@ -198,7 +198,7 @@ TEST_CASE("Intersect coplanar triangles", "[KDTree]") {
         KDTreeIntersection tree_intersection(tree);
 
         Vec origin, dest;
-        KDTree::OptionalId triangle_id;
+        KDTreeIntersection::OptionalId triangle_id;
         float r, s, t;
 
         // ray from negative direction to 0
@@ -224,7 +224,7 @@ TEST_CASE("Intersect coplanar triangles", "[KDTree]") {
 }
 
 TEST_CASE("Optional id can be stored in unordered containers", "[OptionalId]") {
-    std::unordered_set<KDTree::OptionalId> set;
+    std::unordered_set<detail::OptionalId> set;
     set.emplace();
     set.emplace();
     set.emplace(42);
@@ -232,12 +232,12 @@ TEST_CASE("Optional id can be stored in unordered containers", "[OptionalId]") {
     set.emplace(42);
 
     REQUIRE(set.size() == 3);
-    REQUIRE(set.count(KDTree::OptionalId()) == 1);
-    REQUIRE(set.count(KDTree::OptionalId(1)) == 1);
-    REQUIRE(set.count(KDTree::OptionalId(42)) == 1);
+    REQUIRE(set.count(detail::OptionalId()) == 1);
+    REQUIRE(set.count(detail::OptionalId(1)) == 1);
+    REQUIRE(set.count(detail::OptionalId(42)) == 1);
 }
 
-TEST_CASE("Inner FlatNode is constructed correctly", "[FlatNode]") {
+TEST_CASE("Inner Node is constructed correctly", "[node]") {
     float split_pos = 3.1415;
     uint32_t right_index = 42;
     {
@@ -266,7 +266,7 @@ TEST_CASE("Inner FlatNode is constructed correctly", "[FlatNode]") {
     }
 }
 
-TEST_CASE("Set right of inner FlatNode", "[FlatNode]") {
+TEST_CASE("Set right of inner Node", "[node]") {
     float split_pos = 3.1415;
     {
         detail::FlatNode node(Axis::X, split_pos, 0);
@@ -297,29 +297,29 @@ TEST_CASE("Set right of inner FlatNode", "[FlatNode]") {
     }
 }
 
-// TEST_CASE("Leaf FlatNode is constructed correctly", "[FlatNode]") {
-//     {
-//         detail::FlatNode node;
-//         REQUIRE(!node.is_inner());
-//         REQUIRE(node.is_leaf());
-//         REQUIRE(node.is_empty());
-//         REQUIRE(node.is_sentinel());
-//     }
-//     {
-//         detail::FlatNode node(1);
-//         REQUIRE(!node.is_inner());
-//         REQUIRE(node.is_leaf());
-//         REQUIRE(!node.is_empty());
-//         REQUIRE(node.is_sentinel());
-//         REQUIRE(node.first_triangle_id() == 1);
-//     }
-//     {
-//         detail::FlatNode node(1, 2);
-//         REQUIRE(!node.is_inner());
-//         REQUIRE(node.is_leaf());
-//         REQUIRE(!node.is_empty());
-//         REQUIRE(!node.is_sentinel());
-//         REQUIRE(node.first_triangle_id() == 1);
-//         REQUIRE(node.second_triangle_id() == 2);
-//     }
-// }
+TEST_CASE("Leaf Node is constructed correctly", "[node]") {
+    {
+        detail::FlatNode node;
+        REQUIRE(!node.is_inner());
+        REQUIRE(node.is_leaf());
+        REQUIRE(node.is_empty());
+        REQUIRE(node.is_sentinel());
+    }
+    {
+        detail::FlatNode node(1);
+        REQUIRE(!node.is_inner());
+        REQUIRE(node.is_leaf());
+        REQUIRE(!node.is_empty());
+        REQUIRE(node.is_sentinel());
+        REQUIRE(node.first_triangle_id() == 1);
+    }
+    {
+        detail::FlatNode node(1, 2);
+        REQUIRE(!node.is_inner());
+        REQUIRE(node.is_leaf());
+        REQUIRE(!node.is_empty());
+        REQUIRE(!node.is_sentinel());
+        REQUIRE(node.first_triangle_id() == 1);
+        REQUIRE(node.second_triangle_id() == 2);
+    }
+}

--- a/tests/test_kdtree.cpp
+++ b/tests/test_kdtree.cpp
@@ -236,3 +236,32 @@ TEST_CASE("Optional id can be stored in unordered containers", "[OptionalId]") {
     REQUIRE(set.count(KDTree::OptionalId(1)) == 1);
     REQUIRE(set.count(KDTree::OptionalId(42)) == 1);
 }
+
+TEST_CASE("Inner FlatNode is constructed correctly", "[FlatNode]") {
+    float split_pos = 3.1415;
+    uint32_t right_index = 42;
+    {
+        detail::FlatNode node(Axis::X, split_pos, right_index);
+        REQUIRE(node.is_inner());
+        REQUIRE(!node.is_leaf());
+        REQUIRE(node.split_axis() == Axis::X);
+        REQUIRE(node.split_pos() == split_pos);
+        REQUIRE(node.right() == right_index);
+    }
+    {
+        detail::FlatNode node(Axis::Y, split_pos, right_index);
+        REQUIRE(node.is_inner());
+        REQUIRE(!node.is_leaf());
+        REQUIRE(node.split_axis() == Axis::Y);
+        REQUIRE(node.split_pos() == split_pos);
+        REQUIRE(node.right() == right_index);
+    }
+    {
+        detail::FlatNode node(Axis::Z, split_pos, right_index);
+        REQUIRE(node.is_inner());
+        REQUIRE(!node.is_leaf());
+        REQUIRE(node.split_axis() == Axis::Z);
+        REQUIRE(node.split_pos() == split_pos);
+        REQUIRE(node.right() == right_index);
+    }
+}

--- a/tests/test_kdtree.cpp
+++ b/tests/test_kdtree.cpp
@@ -26,7 +26,7 @@ TEST_CASE("Four separated triangles test", "[kdtree]") {
     auto d = test_triangle({3, 2, 1}, {3, 3, 1}, {2, 3, 1});
     KDTree tree(Triangles{a, b, c, d});
     REQUIRE(tree.height() == 1);
-    REQUIRE(tree.num_nodes() == 4);
+    REQUIRE(tree.num_nodes() == 5);
 
     KDTreeIntersection tree_intersection(tree);
     KDTreeIntersection::OptionalId hit;
@@ -303,6 +303,7 @@ TEST_CASE("Leaf Node is constructed correctly", "[node]") {
         REQUIRE(!node.is_inner());
         REQUIRE(node.is_leaf());
         REQUIRE(node.first_triangle_id() == 1);
+        REQUIRE(!node.has_second_triangle_id());
     }
     {
         detail::FlatNode node(1, 2);
@@ -310,5 +311,6 @@ TEST_CASE("Leaf Node is constructed correctly", "[node]") {
         REQUIRE(node.is_leaf());
         REQUIRE(node.first_triangle_id() == 1);
         REQUIRE(node.second_triangle_id() == 2);
+        REQUIRE(node.has_second_triangle_id());
     }
 }

--- a/tests/test_kdtree.cpp
+++ b/tests/test_kdtree.cpp
@@ -271,43 +271,55 @@ TEST_CASE("Set right of inner FlatNode", "[FlatNode]") {
     {
         detail::FlatNode node(Axis::X, split_pos, 0);
         node.set_right(42);
+        REQUIRE(node.is_inner());
+        REQUIRE(!node.is_leaf());
+        REQUIRE(node.split_axis() == Axis::X);
+        REQUIRE(node.split_pos() == split_pos);
         REQUIRE(node.right() == 42);
     }
     {
         detail::FlatNode node(Axis::Y, split_pos, 0);
         node.set_right(42);
+        REQUIRE(node.is_inner());
+        REQUIRE(!node.is_leaf());
+        REQUIRE(node.split_axis() == Axis::Y);
+        REQUIRE(node.split_pos() == split_pos);
         REQUIRE(node.right() == 42);
     }
     {
         detail::FlatNode node(Axis::Z, split_pos, 0);
         node.set_right(42);
+        REQUIRE(node.is_inner());
+        REQUIRE(!node.is_leaf());
+        REQUIRE(node.split_axis() == Axis::Z);
+        REQUIRE(node.split_pos() == split_pos);
         REQUIRE(node.right() == 42);
     }
 }
 
-TEST_CASE("Leaf FlatNode is constructed correctly", "[FlatNode]") {
-    {
-        detail::FlatNode node;
-        REQUIRE(!node.is_inner());
-        REQUIRE(node.is_leaf());
-        REQUIRE(node.is_empty());
-        REQUIRE(node.is_sentinel());
-    }
-    {
-        detail::FlatNode node(1);
-        REQUIRE(!node.is_inner());
-        REQUIRE(node.is_leaf());
-        REQUIRE(!node.is_empty());
-        REQUIRE(node.is_sentinel());
-        REQUIRE(node.first_triangle_id() == 1);
-    }
-    {
-        detail::FlatNode node(1, 2);
-        REQUIRE(!node.is_inner());
-        REQUIRE(node.is_leaf());
-        REQUIRE(!node.is_empty());
-        REQUIRE(!node.is_sentinel());
-        REQUIRE(node.first_triangle_id() == 1);
-        REQUIRE(node.second_triangle_id() == 2);
-    }
-}
+// TEST_CASE("Leaf FlatNode is constructed correctly", "[FlatNode]") {
+//     {
+//         detail::FlatNode node;
+//         REQUIRE(!node.is_inner());
+//         REQUIRE(node.is_leaf());
+//         REQUIRE(node.is_empty());
+//         REQUIRE(node.is_sentinel());
+//     }
+//     {
+//         detail::FlatNode node(1);
+//         REQUIRE(!node.is_inner());
+//         REQUIRE(node.is_leaf());
+//         REQUIRE(!node.is_empty());
+//         REQUIRE(node.is_sentinel());
+//         REQUIRE(node.first_triangle_id() == 1);
+//     }
+//     {
+//         detail::FlatNode node(1, 2);
+//         REQUIRE(!node.is_inner());
+//         REQUIRE(node.is_leaf());
+//         REQUIRE(!node.is_empty());
+//         REQUIRE(!node.is_sentinel());
+//         REQUIRE(node.first_triangle_id() == 1);
+//         REQUIRE(node.second_triangle_id() == 2);
+//     }
+// }

--- a/tests/test_kdtree.cpp
+++ b/tests/test_kdtree.cpp
@@ -265,3 +265,49 @@ TEST_CASE("Inner FlatNode is constructed correctly", "[FlatNode]") {
         REQUIRE(node.right() == right_index);
     }
 }
+
+TEST_CASE("Set right of inner FlatNode", "[FlatNode]") {
+    float split_pos = 3.1415;
+    {
+        detail::FlatNode node(Axis::X, split_pos, 0);
+        node.set_right(42);
+        REQUIRE(node.right() == 42);
+    }
+    {
+        detail::FlatNode node(Axis::Y, split_pos, 0);
+        node.set_right(42);
+        REQUIRE(node.right() == 42);
+    }
+    {
+        detail::FlatNode node(Axis::Z, split_pos, 0);
+        node.set_right(42);
+        REQUIRE(node.right() == 42);
+    }
+}
+
+TEST_CASE("Leaf FlatNode is constructed correctly", "[FlatNode]") {
+    {
+        detail::FlatNode node;
+        REQUIRE(!node.is_inner());
+        REQUIRE(node.is_leaf());
+        REQUIRE(node.is_empty());
+        REQUIRE(node.is_sentinel());
+    }
+    {
+        detail::FlatNode node(1);
+        REQUIRE(!node.is_inner());
+        REQUIRE(node.is_leaf());
+        REQUIRE(!node.is_empty());
+        REQUIRE(node.is_sentinel());
+        REQUIRE(node.first_triangle_id() == 1);
+    }
+    {
+        detail::FlatNode node(1, 2);
+        REQUIRE(!node.is_inner());
+        REQUIRE(node.is_leaf());
+        REQUIRE(!node.is_empty());
+        REQUIRE(!node.is_sentinel());
+        REQUIRE(node.first_triangle_id() == 1);
+        REQUIRE(node.second_triangle_id() == 2);
+    }
+}

--- a/tests/test_kdtree.cpp
+++ b/tests/test_kdtree.cpp
@@ -26,7 +26,7 @@ TEST_CASE("Four separated triangles test", "[kdtree]") {
     auto d = test_triangle({3, 2, 1}, {3, 3, 1}, {2, 3, 1});
     KDTree tree(Triangles{a, b, c, d});
     REQUIRE(tree.height() == 1);
-    REQUIRE(tree.num_nodes() == 5);
+    REQUIRE(tree.num_nodes() == 4);
 
     KDTreeIntersection tree_intersection(tree);
     KDTreeIntersection::OptionalId hit;
@@ -299,26 +299,15 @@ TEST_CASE("Set right of inner Node", "[node]") {
 
 TEST_CASE("Leaf Node is constructed correctly", "[node]") {
     {
-        detail::FlatNode node;
-        REQUIRE(!node.is_inner());
-        REQUIRE(node.is_leaf());
-        REQUIRE(node.is_empty());
-        REQUIRE(node.is_sentinel());
-    }
-    {
         detail::FlatNode node(1);
         REQUIRE(!node.is_inner());
         REQUIRE(node.is_leaf());
-        REQUIRE(!node.is_empty());
-        REQUIRE(node.is_sentinel());
         REQUIRE(node.first_triangle_id() == 1);
     }
     {
         detail::FlatNode node(1, 2);
         REQUIRE(!node.is_inner());
         REQUIRE(node.is_leaf());
-        REQUIRE(!node.is_empty());
-        REQUIRE(!node.is_sentinel());
         REQUIRE(node.first_triangle_id() == 1);
         REQUIRE(node.second_triangle_id() == 2);
     }


### PR DESCRIPTION
Flatten KDTree in a vector after building it up. Use a node of size 8 bytes.

Note: The diff is huge due to the last commit, where I untangle all KDTree interfaces in 3 block. 
1. Building dynamically allocated tree: `KDTreeBuildAlgorithm`,
2. KDTree interfaces + free flatten function,
3. KDTreeIntersection.

Consider, to read commit by commit.

Closes #101 