### PR TITLE
Cache KDTree or load it if cache file exists.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,12 +17,14 @@ endif(COVERAGE)
 
 set(EXT_PROJECTS_DIR ${PROJECT_SOURCE_DIR}/vendor)
 add_subdirectory(${EXT_PROJECTS_DIR}/assimp)
+add_subdirectory(${EXT_PROJECTS_DIR}/cereal)
 add_subdirectory(${EXT_PROJECTS_DIR}/docopt)
 add_subdirectory(${EXT_PROJECTS_DIR}/openmesh)
 add_subdirectory(${EXT_PROJECTS_DIR}/threadpool)
 
 include_directories(
 	${assimp_INCLUDE_DIR}
+	${cereal_INCLUDE_DIR}
 	${docopt_INCLUDE_DIR}
 	${threadpool_INCLUDE_DIR}
 	${openmesh_INCLUDE_DIR}
@@ -39,7 +41,7 @@ add_library(common OBJECT ${LIB_SRCS})
 add_dependencies(common assimp zlibstatic)
 
 add_library(main OBJECT main.cpp)
-add_dependencies(main assimp zlibstatic docopt threadpool)
+add_dependencies(main assimp zlibstatic cereal docopt threadpool)
 
 find_package(Threads REQUIRED)
 
@@ -65,7 +67,7 @@ target_link_libraries(pathtracer
 )
 
 add_executable(radiosity radiosity.cpp $<TARGET_OBJECTS:common>)
-add_dependencies(radiosity docopt openmesh threadpool)
+add_dependencies(radiosity cereal docopt openmesh threadpool)
 target_link_libraries(radiosity
 	Threads::Threads
 	${assimp_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ file(GLOB LIB_SRCS
 )
 
 add_library(common OBJECT ${LIB_SRCS})
-add_dependencies(common assimp zlibstatic)
+add_dependencies(common assimp cereal zlibstatic)
 
 add_library(main OBJECT main.cpp)
 add_dependencies(main assimp zlibstatic cereal docopt threadpool)

--- a/lib/kdtree.h
+++ b/lib/kdtree.h
@@ -68,7 +68,7 @@ public:
 
 public:
 
-    FlatNode() {};
+    FlatNode() = default;
 
     // Inner node containing split axis and pos, and index of the right child
     FlatNode(Axis split_axis, float split_pos, uint32_t right)
@@ -192,7 +192,7 @@ class KDTree {
 public:
     using TriangleId = detail::TriangleId;
 
-    KDTree() {};
+    KDTree() = default;
 
     explicit KDTree(Triangles tris);
 

--- a/lib/kdtree.h
+++ b/lib/kdtree.h
@@ -67,7 +67,6 @@ public:
     constexpr static uint32_t INVALID_TRIANGLE_ID = 0xFFFFFFFF >> 2;
 
 public:
-
     FlatNode() = default;
 
     // Inner node containing split axis and pos, and index of the right child
@@ -134,8 +133,7 @@ public:
         return (data_ & 0xFFFFFFFF) >> 2;
     }
 
-    template <class Archive>
-    void serialize(Archive & archive) {
+    template <class Archive> void serialize(Archive& archive) {
         archive(data_);
     }
 
@@ -227,9 +225,7 @@ public:
 
     static constexpr size_t node_size() { return sizeof(detail::FlatNode); }
 
-    template<class Archive>
-    void serialize(Archive & archive)
-    {
+    template <class Archive> void serialize(Archive& archive) {
         archive(tris_, box_, nodes_);
     }
 

--- a/lib/kdtree.h
+++ b/lib/kdtree.h
@@ -22,6 +22,7 @@
 
 #include "triangle.h"
 
+#include <cereal/types/vector.hpp>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -66,6 +67,9 @@ public:
     constexpr static uint32_t INVALID_TRIANGLE_ID = 0xFFFFFFFF >> 2;
 
 public:
+
+    FlatNode() {};
+
     // Inner node containing split axis and pos, and index of the right child
     FlatNode(Axis split_axis, float split_pos, uint32_t right)
         : data_(static_cast<uint64_t>(float_to_uint32(split_pos)) << 32 |
@@ -130,6 +134,11 @@ public:
         return (data_ & 0xFFFFFFFF) >> 2;
     }
 
+    template <class Archive>
+    void serialize(Archive & archive) {
+        archive(data_);
+    }
+
 private:
     /**
      * Memory layout:
@@ -183,6 +192,8 @@ class KDTree {
 public:
     using TriangleId = detail::TriangleId;
 
+    KDTree() {};
+
     explicit KDTree(Triangles tris);
 
     size_t height() const {
@@ -215,6 +226,12 @@ public:
     const Triangle& at(const TriangleId id) const { return tris_.at(id); }
 
     static constexpr size_t node_size() { return sizeof(detail::FlatNode); }
+
+    template<class Archive>
+    void serialize(Archive & archive)
+    {
+        archive(tris_, box_, nodes_);
+    }
 
 private:
     Triangles tris_;

--- a/lib/triangle.h
+++ b/lib/triangle.h
@@ -15,7 +15,6 @@
 //
 class Triangle {
 public:
-
     Triangle() = default;
 
     Triangle(std::array<Vec, 3> vs, std::array<Vec, 3> ns,
@@ -86,8 +85,7 @@ public:
         return is_eps_zero(normal.x) && is_eps_zero(normal.y);
     }
 
-    template<class Archive>
-    void serialize(Archive& archive) {
+    template <class Archive> void serialize(Archive& archive) {
         archive(vertices, normals, ambient, diffuse, emissive, reflective,
                 reflectivity, u, v, normal, uv, vv, uu, denom);
     }

--- a/lib/triangle.h
+++ b/lib/triangle.h
@@ -3,6 +3,8 @@
 #include "types.h"
 
 #include <array>
+#include <cereal/types/array.hpp>
+#include <cereal/types/vector.hpp>
 #include <vector>
 
 //
@@ -13,6 +15,9 @@
 //
 class Triangle {
 public:
+
+    Triangle() {};
+
     Triangle(std::array<Vec, 3> vs, std::array<Vec, 3> ns,
              const aiColor4D& ambient, const aiColor4D& diffuse,
              const aiColor4D& emissive, const aiColor4D& reflective,
@@ -79,6 +84,12 @@ public:
             return is_eps_zero(normal.x) && is_eps_zero(normal.z);
         }
         return is_eps_zero(normal.x) && is_eps_zero(normal.y);
+    }
+
+    template<class Archive>
+    void serialize(Archive& archive) {
+        archive(vertices, normals, ambient, diffuse, emissive, reflective,
+                reflectivity, u, v, normal, uv, vv, uu, denom);
     }
 
     // members

--- a/lib/triangle.h
+++ b/lib/triangle.h
@@ -16,7 +16,7 @@
 class Triangle {
 public:
 
-    Triangle() {};
+    Triangle() = default;
 
     Triangle(std::array<Vec, 3> vs, std::array<Vec, 3> ns,
              const aiColor4D& ambient, const aiColor4D& diffuse,

--- a/lib/triangle.h
+++ b/lib/triangle.h
@@ -2,9 +2,10 @@
 
 #include "types.h"
 
-#include <array>
 #include <cereal/types/array.hpp>
 #include <cereal/types/vector.hpp>
+
+#include <array>
 #include <vector>
 
 //

--- a/lib/types.h
+++ b/lib/types.h
@@ -67,6 +67,11 @@ public:
     bool operator<=(const Vec& v) const {
         return x <= v.x && y <= v.y && z <= v.z;
     }
+
+    template<class Archive>
+    void serialize(Archive& archive) {
+        archive(x, y, z);
+    }
 };
 
 inline Vec operator/(int a, const Vec& v) {
@@ -97,6 +102,11 @@ inline float fmin(float x, float y, float z) {
 
 inline float fmax(float x, float y, float z) {
     return std::fmax(x, std::max(y, z));
+}
+
+template<class Archive>
+void serialize(Archive& archive, Color& c) {
+    archive(c.r, c.g, c.b, c.a);
 }
 
 /**
@@ -145,6 +155,11 @@ struct Box {
         rmin[plane_ax] = plane_pos;
 
         return {{this->min, lmax}, {rmin, this->max}};
+    }
+
+    template<class Archive>
+    void serialize(Archive& archive) {
+        archive(min, max);
     }
 
     Vec min, max;

--- a/lib/types.h
+++ b/lib/types.h
@@ -68,8 +68,7 @@ public:
         return x <= v.x && y <= v.y && z <= v.z;
     }
 
-    template<class Archive>
-    void serialize(Archive& archive) {
+    template <class Archive> void serialize(Archive& archive) {
         archive(x, y, z);
     }
 };
@@ -104,8 +103,7 @@ inline float fmax(float x, float y, float z) {
     return std::fmax(x, std::max(y, z));
 }
 
-template<class Archive>
-void serialize(Archive& archive, Color& c) {
+template <class Archive> void serialize(Archive& archive, Color& c) {
     archive(c.r, c.g, c.b, c.a);
 }
 
@@ -157,8 +155,7 @@ struct Box {
         return {{this->min, lmax}, {rmin, this->max}};
     }
 
-    template<class Archive>
-    void serialize(Archive& archive) {
+    template <class Archive> void serialize(Archive& archive) {
         archive(min, max);
     }
 

--- a/main.cpp
+++ b/main.cpp
@@ -16,10 +16,10 @@
 #include <cereal/archives/portable_binary.hpp>
 #include <docopt/docopt.h>
 
+#include <fstream>
 #include <iostream>
 #include <map>
 #include <math.h>
-#include <fstream>
 #include <vector>
 
 Triangles triangles_from_scene(const aiScene* scene) {
@@ -131,21 +131,21 @@ int main(int argc, char const* argv[]) {
     {
         Runtime runtime(kdtree_runtime_ms);
         std::ifstream kdtree_cache("kdtree.cache");
-        if(kdtree_cache.is_open()) {
+        if (kdtree_cache.is_open()) {
             {
                 cereal::PortableBinaryInputArchive iarchive(kdtree_cache);
                 iarchive(tree);
             }
-            kdtree_cache.close();
         } else {
             // Build tree
             auto triangles = triangles_from_scene(scene);
             tree = KDTree(std::move(triangles));
 
             // Cache KDTree
-            std::ofstream output_file;
             {
-                output_file.open("kdtree.cache", std::ios::out | std::ios::binary);
+                std::ofstream output_file;
+                output_file.open("kdtree.cache",
+                                 std::ios::out | std::ios::binary);
                 cereal::PortableBinaryOutputArchive oarchive(output_file);
                 oarchive(tree);
                 output_file.close();

--- a/main.cpp
+++ b/main.cpp
@@ -148,7 +148,6 @@ int main(int argc, char const* argv[]) {
                                  std::ios::out | std::ios::binary);
                 cereal::PortableBinaryOutputArchive oarchive(output_file);
                 oarchive(tree);
-                output_file.close();
             }
         }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TESTS
     test_lambertian
     test_progress_bar
     test_radiosity
+    test_range
     test_raster
     test_sampling
     test_triangle

--- a/tests/test_range.cpp
+++ b/tests/test_range.cpp
@@ -1,0 +1,17 @@
+#include "../lib/range.h"
+#include <catch.hpp>
+
+TEST_CASE("Test range", "[helper]")
+{
+    // C-style array of prime number.
+    int data[4] = { 2, 41, 3, 7};
+
+    auto data_range = make_range(data, 4);
+
+    // Determine invariant.
+    int invariant = 0;
+    for(auto next : data_range) {
+        invariant += next;
+    }
+    REQUIRE(invariant == 53);
+}

--- a/tests/test_types.cpp
+++ b/tests/test_types.cpp
@@ -4,6 +4,7 @@
 #include "../lib/output.h"
 #include "../lib/runtime.h"
 #include <catch.hpp>
+#include <cereal/archives/portable_binary.hpp>
 
 
 TEST_CASE("Test min and max", "[helper]") {
@@ -100,6 +101,30 @@ TEST_CASE("Test is_planar of triangle", "[triangle]")
         Triangle triangle = test_triangle(vs[0], vs[1], vs[2]);
         REQUIRE(triangle.is_planar(ax));
     }
+}
+
+TEST_CASE("Test serialization of triangle", "[triangle]")
+{
+    Triangle tri_out = test_triangle(random_vec(), random_vec(), random_vec());
+
+    // Serialize triangle
+    std::ostringstream os;
+    {
+        cereal::PortableBinaryOutputArchive oarchive(os);
+        oarchive(tri_out);
+    }
+
+    // Deserialize triangle again
+    Triangle tri_in;
+    std::istringstream is(os.str());
+    {
+        cereal::PortableBinaryInputArchive iarchive(is);
+        iarchive(tri_in);
+    }
+
+    REQUIRE(tri_in.vertices[0] == tri_out.vertices[0]);
+    REQUIRE(tri_in.vertices[1] == tri_out.vertices[1]);
+    REQUIRE(tri_in.vertices[2] == tri_out.vertices[2]);
 }
 
 TEST_CASE("Test clamping", "[clamping]")

--- a/vendor/cereal/CMakeLists.txt
+++ b/vendor/cereal/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(Git REQUIRED)
 ExternalProject_Add(
     cereal
     PREFIX ${CMAKE_BINARY_DIR}/vendor/cereal
+    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
     GIT_REPOSITORY https://github.com/USCiLab/cereal.git
     GIT_TAG v1.2.2
     UPDATE_COMMAND ""

--- a/vendor/cereal/CMakeLists.txt
+++ b/vendor/cereal/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.2)
+set_directory_properties(PROPERTIES CLEAN_NO_CUSTOM 1)
+include(ExternalProject)
+find_package(Git REQUIRED)
+
+ExternalProject_Add(
+    cereal
+    PREFIX ${CMAKE_BINARY_DIR}/vendor/cereal
+    GIT_REPOSITORY https://github.com/USCiLab/cereal.git
+    GIT_TAG v1.2.2
+    UPDATE_COMMAND ""
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    LOG_DOWNLOAD ON
+)
+
+ExternalProject_Get_Property(cereal source_dir)
+set(cereal_INCLUDE_DIR ${source_dir}/include
+    CACHE INTERNAL "Path to include folder for Cereal"
+)


### PR DESCRIPTION
This is a prototype serialization for caching the KDTree once it's built. We use cereal to write out the KDTree in a binary file.

Loading the tree for the dragon takes less than 3 second. Building the tree took more than 6 minutes.